### PR TITLE
[Offload] Allow kernel launch with unknown argument layout

### DIFF
--- a/llvm/include/llvm/Frontend/Offloading/Utility.h
+++ b/llvm/include/llvm/Frontend/Offloading/Utility.h
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <memory>
 
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/Module.h"
@@ -114,6 +115,19 @@ namespace amdgpu {
 LLVM_ABI bool isImageCompatibleWithEnv(StringRef ImageArch, uint32_t ImageFlags,
                                        StringRef EnvTargetID);
 
+/// The offset and size of an AMD GPU kernel argument, as read from MetaData.
+struct AMDGPUKernelArgumentInfo {
+  // Address space and value kind are available but not stored right now.
+  uint32_t Offset;
+  uint32_t Size;
+};
+
+/// Container for the kernel argument layout, as read from MetaData.
+struct AMDGPUKernelArgumentLayout {
+  SmallVector<AMDGPUKernelArgumentInfo, 32> Arguments;
+  int32_t NumUserArguments = -1;
+};
+
 /// Struct for holding metadata related to AMDGPU kernels, for more information
 /// about the metadata and its meaning see:
 /// https://llvm.org/docs/AMDGPUUsage.html#code-object-v3
@@ -147,6 +161,8 @@ struct AMDGPUKernelMetaData {
   uint32_t WavefrontSize = KInvalidValue;
   /// Maximum flat work-group size supported by the kernel in work-items.
   uint32_t MaxFlatWorkgroupSize = KInvalidValue;
+  /// The argument layout of this kernel.
+  AMDGPUKernelArgumentLayout ArgumentLayout;
 };
 
 /// Reads AMDGPU specific metadata from the ELF file and propagates the

--- a/llvm/lib/Frontend/Offloading/Utility.cpp
+++ b/llvm/lib/Frontend/Offloading/Utility.cpp
@@ -237,9 +237,10 @@ private:
   /// Extracts the relevant information via simple string look-up in the msgpack
   /// document elements.
   Error
-  extractKernelData(msgpack::MapDocNode::MapTy::value_type V,
+  extractKernelData(msgpack::MapDocNode::MapTy::iterator &It,
                     std::string &KernelName,
                     offloading::amdgpu::AMDGPUKernelMetaData &KernelData) {
+    msgpack::MapDocNode::MapTy::value_type V = *It;
     if (!V.first.isString())
       return Error::success();
 
@@ -260,8 +261,35 @@ private:
       }
     };
 
+    auto GetArgumentLayout =
+        [&](msgpack::DocNode &DN,
+            amdgpu::AMDGPUKernelArgumentLayout &ArgumentLayout) {
+          assert(DN.isArray() && "MsgPack DocNode is an array node");
+          for (auto &Node : DN.getArray()) {
+            uint32_t Offset = -1, Size = -1;
+            for (auto It : Node.getMap()) {
+              if (IsKey(It.first, ".address_space"))
+                /* Ignored */;
+              else if (IsKey(It.first, ".offset"))
+                Offset = It.second.getUInt();
+              else if (IsKey(It.first, ".size"))
+                Size = It.second.getUInt();
+              else if (IsKey(It.first, ".value_kind"))
+                if (ArgumentLayout.NumUserArguments == -1 &&
+                    It.second.getString().starts_with("hidden_"))
+                  ArgumentLayout.NumUserArguments =
+                      ArgumentLayout.Arguments.size();
+            }
+            assert(Offset != -1u && Size != -1u &&
+                   "Expected both offset and size!");
+            ArgumentLayout.Arguments.push_back({Offset, Size});
+          }
+        };
+
     if (IsKey(V.first, ".name")) {
       KernelName = V.second.toString();
+    } else if (IsKey(V.first, ".args")) {
+      GetArgumentLayout(V.second, KernelData.ArgumentLayout);
     } else if (IsKey(V.first, ".sgpr_count")) {
       KernelData.SGPRCount = V.second.getUInt();
     } else if (IsKey(V.first, ".sgpr_spill_count")) {
@@ -312,7 +340,7 @@ private:
     std::string KernelName;
     auto Entry = (*It).getMap();
     for (auto MI = Entry.begin(), E = Entry.end(); MI != E; ++MI)
-      if (auto Err = extractKernelData(*MI, KernelName, KernelData))
+      if (auto Err = extractKernelData(MI, KernelName, KernelData))
         return Err;
 
     KernelInfoMap.insert({KernelName, KernelData});

--- a/offload/include/Shared/APITypes.h
+++ b/offload/include/Shared/APITypes.h
@@ -119,6 +119,9 @@ static_assert(sizeof(KernelArgsTy) ==
 
 /// Flat array of kernel launch parameters and their total size.
 struct KernelLaunchParamsTy {
+  /// Constant used to signal the size is unknown and the Data is actually a
+  /// pointer array to the arguments.
+  static constexpr size_t UnknownSize = ~size_t(0);
   /// Size of the Data array.
   size_t Size = 0;
   /// Flat array of kernel parameters.

--- a/offload/liboffload/API/Device.td
+++ b/offload/liboffload/API/Device.td
@@ -134,3 +134,28 @@ def : Function {
     Return<"OL_ERRC_INVALID_DEVICE">
   ];
 }
+
+def : Function {
+  let name = "olElfIsCompatibleWithDevice";
+  let desc = "Checks if the given ELF binary is compatible with the specified device.";
+  let details = [
+    "This function determines whether an ELF image can be executed on the specified device."
+  ];
+  let params = [
+    Param<"ol_device_handle_t", "Device", "handle of the device to check against", PARAM_IN>,
+    Param<"const void*", "ElfData", "pointer to the ELF image data in memory", PARAM_IN>,
+    Param<"size_t", "ElfSize", "size in bytes of the ELF image", PARAM_IN>,
+    Param<"bool*", "IsCompatible", "set to true if the ELF is compatible, false otherwise", PARAM_OUT>
+  ];
+  let returns = [
+    Return<"OL_ERRC_INVALID_DEVICE", [
+      "If the provided device handle is invalid."
+    ]>,
+    Return<"OL_ERRC_INVALID_ARGUMENT", [
+      "If `ElfData` is null or `ElfSize` is zero."
+    ]>,
+    Return<"OL_ERRC_NULL_POINTER", [
+      "If `IsCompatible` is null."
+    ]>
+  ];
+}

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -502,6 +502,27 @@ Error olGetDeviceInfoSize_impl(ol_device_handle_t Device,
   return olGetDeviceInfoImplDetail(Device, PropName, 0, nullptr, PropSizeRet);
 }
 
+Error olElfIsCompatibleWithDevice_impl(ol_device_handle_t Device,
+                                       const void *ElfData, size_t ElfSize,
+                                       bool *IsCompatible) {
+  GenericDeviceTy *DeviceTy = Device->Device;
+  int32_t DeviceId = DeviceTy->getDeviceId();
+  GenericPluginTy &DevicePlugin = DeviceTy->Plugin;
+
+  StringRef Image(reinterpret_cast<const char *>(ElfData), ElfSize);
+
+  Expected<bool> ResultOrErr = DevicePlugin.isELFCompatible(DeviceId, Image);
+  if (!ResultOrErr) {
+    consumeError(ResultOrErr.takeError());
+    return createOffloadError(
+        ErrorCode::INVALID_ARGUMENT,
+        "elf compatibility can not be checked for device");
+  }
+
+  *IsCompatible = *ResultOrErr;
+  return Error::success();
+}
+
 Error olIterateDevices_impl(ol_device_iterate_cb_t Callback, void *UserData) {
   for (auto &Platform : OffloadContext::get().Platforms) {
     for (auto &Device : Platform.Devices) {

--- a/offload/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/offload/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -3570,11 +3570,35 @@ Error AMDGPUKernelTy::launchImpl(GenericDeviceTy &GenericDevice,
   if (auto Err = GenericDevice.getDeviceStackSize(StackSize))
     return Err;
 
+  uint32_t LaunchParamsSizePadded = 0;
   // Copy the explicit arguments.
   // TODO: We should expose the args memory manager alloc to the common part as
   // 	   alternative to copying them twice.
-  if (LaunchParams.Size)
-    std::memcpy(AllArgs, LaunchParams.Data, LaunchParams.Size);
+  if (LaunchParams.Size != KernelLaunchParamsTy::UnknownSize) {
+    LaunchParamsSizePadded = utils::roundUp(LaunchParams.Size, sizeof(void *));
+    __builtin_memcpy(AllArgs, LaunchParams.Data, LaunchParams.Size);
+  } else {
+    if (!KernelInfo)
+      return Plugin::error(ErrorCode::INVALID_ARGUMENT,
+                           "Unkown kernel argument layout!");
+    auto &ArgumentLayout = (*KernelInfo).ArgumentLayout;
+    void **ValuePtrs = (void **)LaunchParams.Data;
+    for (int32_t I = 0; I < ArgumentLayout.NumUserArguments; ++I) {
+      auto &Arg = ArgumentLayout.Arguments[I];
+      void *ArgPtr = utils::advancePtr(AllArgs, Arg.Offset);
+      __builtin_memcpy(ArgPtr, ValuePtrs[I], Arg.Size);
+    }
+    if (ArgumentLayout.NumUserArguments) {
+      auto &Arg = ArgumentLayout.Arguments[ArgumentLayout.NumUserArguments - 1];
+      LaunchParamsSizePadded =
+          utils::roundUp(size_t(Arg.Offset + Arg.Size), sizeof(void *));
+    }
+  }
+
+  if (ArgsSize != LaunchParamsSizePadded &&
+      ArgsSize != LaunchParamsSizePadded + getImplicitArgsSize())
+    return Plugin::error(ErrorCode::INVALID_ARGUMENT,
+                         "Mismatch of kernel arguments size");
 
   AMDGPUDeviceTy &AMDGPUDevice = static_cast<AMDGPUDeviceTy &>(GenericDevice);
 


### PR DESCRIPTION
The C-style CUDA/HIP kernel launch API does not require information about the arguments. To launch the kernel the driver needs to accept this vector of argument pointers, or we need to identify their layout. For CUDA we simply ask the driver to do the work, for AMD/HSA we do it by scanning the kernel metadata and arranging the arguments ourselves